### PR TITLE
gallery-email-parse: Fix compatibilty with new requests

### DIFF
--- a/scripts/gallery-email-parse.py
+++ b/scripts/gallery-email-parse.py
@@ -47,7 +47,7 @@ def upload_image(description, author, imagedata, filename):
     files = {'imagefile': (filename, imagedata) }
     payload = {'key': secret_key, 'description': description}
 
-    r = requests.post(apiurl, files=files, data=payload, config={'verbose': sys.stderr})
+    r = requests.post(apiurl, files=files, data=payload)
 
     print r.text
 


### PR DESCRIPTION
The `config` option was removed in requests 1.0+

Fixes exception in sending to galleri email of form:
    TypeError: request() got an unexpected keyword argument 'config'